### PR TITLE
MINOR formatting fix: title was not displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Ascii Py
+# Ascii Py
 
 Makin some pictures
 


### PR DESCRIPTION
The title was not displayed correctly because it lacked the space needed by the GitHub markdown engine.  This is a Very Minor change to the documentation.